### PR TITLE
fix bug that caused the first timestamp to be skipped

### DIFF
--- a/source/glue/amc_transformations.py
+++ b/source/glue/amc_transformations.py
@@ -452,6 +452,11 @@ if timestamp_column:
             if timestamp_str_old == '':
                 # ...unless we're just starting out.
                 timestamp_str_old = timestamp_str
+                # Get all the events that occurred at the first timestamp
+                # so that they can be recorded when we read the next timestamp.
+                df_partition = df[df[timestamp_column] == timestamp]
+                df_partition[timestamp_column] = df_partition[timestamp_column].dt.strftime(datetime_format)
+                # Now proceed to the next unique timestamp.
                 continue
             # write the old df_partition to s3
             output_file = 's3://'+output_bucket+'/'+amc_str+'/'+dataset_id+'/'+timeseries_partition_size+'/'+filename+'-'+timestamp_str_old+'.gz'


### PR DESCRIPTION
*Issue #, if available:*

Closes #11 

*Description of changes:*

We forgot to record the first timeseries record before proceeding to the next timestamp. This fixes that problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
