### PR TITLE
Feature: Allow users to select more that one file in Step 1 and upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Allow users to upload multiple S3 files at the same time [#41]
 - Allow users to specify FACT partition size [#52]
 - Record anonymous performance metrics to measure ETL workload size [#52]
 - Automate integration tests [#42]

--- a/deployment/glue.yaml
+++ b/deployment/glue.yaml
@@ -391,7 +391,7 @@ Resources:
         "--deleted_fields": ""
         "--dataset_id": ""
       ExecutionProperty:
-        MaxConcurrentRuns: 2
+        MaxConcurrentRuns: 200
       MaxRetries: 0
 
 Outputs:

--- a/source/api/app.py
+++ b/source/api/app.py
@@ -334,7 +334,7 @@ def get_data_columns():
 
         # for concurrent glue jobs, can only run a max of 200 per account
         if(len(keys_to_validate) > 200):
-            return Response(body={"Error": "Number of files selected cannot exceed 200"},
+            return Response(body={"message": "Number of files selected cannot exceed 200"},
                             status_code=400,
                             headers={'Content-Type': 'text/plain'})
         
@@ -366,14 +366,14 @@ def get_data_columns():
                 error_text = "Schemas must match for each file. The schemas in " + \
                              key + " and " + base_key + " do not match."
                 logger.error(error_text)
-                return Response(body={"Error": error_text},
+                return Response(body={"message": error_text},
                                 status_code=400,
                                 headers={'Content-Type': 'text/plain'})
 
         return result
     except Exception as e:
         logger.error(e)
-        return {"Status": "Error", "Message": json.dumps(e)}
+        return {"Status": "Error", "Message": e}
 
 
 def log_request_parameters():

--- a/source/helper/webapp-manifest.json
+++ b/source/helper/webapp-manifest.json
@@ -1,1 +1,0 @@
-["index.html","css/chunk-vendors.79ba555c.css","css/app.80821710.css","js/app.e05cd657.js.map","js/chunk-vendors.faee2062.js","js/chunk-vendors.faee2062.js.map","js/app.e05cd657.js","runtimeConfig.json","manifest.json","robots.txt"]

--- a/source/helper/webapp-manifest.json
+++ b/source/helper/webapp-manifest.json
@@ -1,0 +1,1 @@
+["index.html","css/chunk-vendors.79ba555c.css","css/app.80821710.css","js/app.e05cd657.js.map","js/chunk-vendors.faee2062.js","js/chunk-vendors.faee2062.js.map","js/app.e05cd657.js","runtimeConfig.json","manifest.json","robots.txt"]

--- a/source/website/src/views/Step1.vue
+++ b/source/website/src/views/Step1.vue
@@ -56,7 +56,7 @@ SPDX-License-Identifier: Apache-2.0
                 :items="results"
                 :fields="fields"
                 :busy="isBusy"
-                select-mode="single"
+                select-mode="multi"
                 responsive="sm"
                 selectable
                 small
@@ -133,7 +133,9 @@ SPDX-License-Identifier: Apache-2.0
         this.$router.push('Step2')
       },
       onRowSelected(items) {
-        this.new_s3key = items[0].key
+        let newKeys = [];
+        for(let item of items) newKeys.push(item.key)
+        this.new_s3key = newKeys.join(", ");
       },
       async send_request(method, resource, data) {
         this.results = []

--- a/source/website/src/views/Step1.vue
+++ b/source/website/src/views/Step1.vue
@@ -8,13 +8,27 @@ SPDX-License-Identifier: Apache-2.0
     <div class="headerTextBackground">
       <Header />
       <b-container fluid>
+        <b-modal id="modal-file-format" title="File Format Requirements">
+          <p><strong>CSV</strong> files must include a header, be UTF-8 encoded, and comma delimited.</p>
+          <p><strong>JSON</strong> files must contain one object per row of data. Each row must be a top-level object. No parent object or array may be present in the JSON file. An example of the accepted JSON format is shown below:</p>
+          <pre>
+{"name": "Product A", "sku": 11352987, "quantity": 2, "pur_time": "2021-06-23T19:53:58Z"} 
+{"name": "Product B", "sku": 18467234, "quantity": 2, "pur_time": "2021-06-24T19:53:58Z"} 
+{"name": "Product C", "sku": 27264393, "quantity": 2, "pur_time": "2021-06-25T19:53:58Z"} 
+{"name": "Product A", "sku": 48572094, "quantity": 2, "pur_time": "2021-06-25T19:53:58Z"} 
+{"name": "Product B", "sku": 18278476, "quantity": 1, "pur_time": "2021-06-26T13:33:58Z"}
+            </pre>
+        </b-modal>
         <b-row style="text-align: left">
           <b-col cols="2">
             <Sidebar :is-step1-active="true" />
           </b-col>
           <b-col cols="10">
-            <h3>Select file</h3>
-            Select a file to ingest into Amazon Marketing Cloud.
+            <h3>Select files</h3>
+            Select one or more files to ingest. Files must be formatted as CSV or JSON with identical schemas.
+            <b-link v-b-modal.modal-file-format>
+              <b-icon-question-circle-fill variant="secondary"></b-icon-question-circle-fill>
+            </b-link>
             <br>
             <br>
             <div>
@@ -33,8 +47,7 @@ SPDX-License-Identifier: Apache-2.0
                     id="s3key-label"
                     label-cols-lg="2"
                     label-align-lg="left"
-                    description="Select a file"
-                    label="Key:"
+                    label="Keys:"
                     label-for="s3key-input"
                   >
                     <b-form-input id="s3key-input" v-model="new_s3key"></b-form-input>

--- a/source/website/src/views/Step3.vue
+++ b/source/website/src/views/Step3.vue
@@ -68,7 +68,7 @@ SPDX-License-Identifier: Apache-2.0
             </b-alert>
             <b-row>
               <b-col>
-                Fill in the table to define properties for each field in {{ s3key }}.
+                Fill in the table to define properties for each field in the input data.
               </b-col>
               <b-col sm="3" align="right" class="row align-items-end">
                 <button type="submit" class="btn btn-outline-primary mb-2" @click="$router.push('Step2')">
@@ -265,7 +265,7 @@ SPDX-License-Identifier: Apache-2.0
         this.showMissingDataAlert = true
       }
       else if (!this.step3_form_input.length) {
-        this.send_request('POST', 'get_data_columns', {'s3bucket': this.DATA_BUCKET_NAME, 's3key':this.s3key, 'file_format':this.dataset_definition.fileFormat})
+        this.send_request('POST', 'get_data_columns', {'s3bucket': this.DATA_BUCKET_NAME, 's3key':this.s3key})
       } else {
         this.items = this.step3_form_input
       }
@@ -279,7 +279,7 @@ SPDX-License-Identifier: Apache-2.0
       },
       onReset() {
         this.$store.commit('updateDeletedColumns', [])
-        this.send_request('POST', 'get_data_columns', {'s3bucket': this.DATA_BUCKET_NAME, 's3key':this.s3key, 'file_format':this.dataset_definition.fileFormat})
+        this.send_request('POST', 'get_data_columns', {'s3bucket': this.DATA_BUCKET_NAME, 's3key':this.s3key})
         this.column_type_options.forEach(x => x.disabled = false)
         this.pii_type_options.forEach(x => x.disabled = false)
       },

--- a/source/website/src/views/Step3.vue
+++ b/source/website/src/views/Step3.vue
@@ -22,6 +22,13 @@ SPDX-License-Identifier: Apache-2.0
         >
           Missing s3key. Go back and select a file. 
         </b-alert>
+        <b-alert 
+          v-model="showSchemaError"
+          variant="danger"
+          dismissible
+        >
+          Schemas must match for each file when multi-uploading.
+        </b-alert>
         <b-alert
           v-model="showUserIdWarning"
           variant="danger"
@@ -175,6 +182,7 @@ SPDX-License-Identifier: Apache-2.0
         new_dataset_definition: {},
         isBusy: false,
         showServerError: false,
+        showSchemaError: false,
         showMissingDataAlert: false,
         showIncompleteFieldsError: false,
         showIncompleteTimeFieldError: false,
@@ -458,9 +466,11 @@ SPDX-License-Identifier: Apache-2.0
           console.log(JSON.stringify(this.items))
         }
         catch (e) {
+          if(e.response.status === 400) this.showSchemaError = true;
+          else this.showServerError = true;
+
           console.log("ERROR: " + e.response.data.message)
           this.isBusy = false;
-          this.showServerError = true;
           this.results = e.response.data.message
         }
         this.isBusy = false;

--- a/source/website/src/views/Step3.vue
+++ b/source/website/src/views/Step3.vue
@@ -191,6 +191,7 @@ SPDX-License-Identifier: Apache-2.0
         userIdWarningMessage: "Do not include user_id and user_type columns in data files containing hashed identifiers. These columns are used by AMC when a match is found in a hashed record.",
         items: [],
         columns: [],
+        content_type: "",
         fields: [
           { key: 'name', sortable: true },
           { key: 'description', sortable: false },
@@ -385,6 +386,14 @@ SPDX-License-Identifier: Apache-2.0
           }
           )
         this.new_dataset_definition['columns'] = this.columns
+        if (this.content_type === "application/json") 
+          this.new_dataset_definition['fileFormat'] = 'JSON'
+        else if (this.content_type === "text/csv")
+          this.new_dataset_definition['fileFormat'] = 'CSV'
+        else
+          console.log("ERROR: unrecognized content_type, " + this.content_type)
+          this.showServerError = true;
+          
         this.$store.commit('updateDatasetDefinition', this.new_dataset_definition)
         this.$router.push('Step4')
       },
@@ -451,6 +460,7 @@ SPDX-License-Identifier: Apache-2.0
             "column_type": "", 
             "pii_type": ""}
           }).filter(x => !this.deleted_columns.includes(x.name) )
+          
           // warn if table contains hashed identifiers and user_id or user_type columns
           const idx = this.items.findIndex((x => x.name === "user_id"))
           if (idx >= 0) {
@@ -462,7 +472,7 @@ SPDX-License-Identifier: Apache-2.0
             this.items[idx2]._rowVariant = 'danger'
             this.showUserIdWarning = true;
           }
-
+          this.content_type = response.content_type
           console.log(JSON.stringify(this.items))
         }
         catch (e) {

--- a/source/website/src/views/Step4.vue
+++ b/source/website/src/views/Step4.vue
@@ -38,8 +38,8 @@ SPDX-License-Identifier: Apache-2.0
             </b-row>
             <b-row>
               <b-col cols="7">
-                <h5>Input file:</h5>
-                {{ "s3://" + DATA_BUCKET_NAME + "/" + s3key }}
+                <h5>Input files from {{"s3://" + DATA_BUCKET_NAME}}:</h5>
+                {{ s3key }}
                 <br>
                 <br>
                 <h5>Dataset Attributes:</h5>
@@ -168,18 +168,22 @@ SPDX-License-Identifier: Apache-2.0
           console.log("Dataset defined successfully")
           
           // Start Glue ETL job now that the dataset has been accepted by AMC
-          console.log("Starting Glue ETL job for s3://" + this.DATA_BUCKET_NAME + "/" + this.s3key)
-          resource = 'start_amc_transformation'
-          data = {'sourceBucket': this.DATA_BUCKET_NAME, 'sourceKey': this.s3key, 'outputBucket': this.ARTIFACT_BUCKET_NAME, 'piiFields': JSON.stringify(this.pii_fields),'deletedFields': JSON.stringify(this.deleted_columns), 'timestampColumn': this.timestamp_column_name, 'datasetId': this.dataset_definition.dataSetId}
-          let requestOpts = {
-            headers: {'Content-Type': 'application/json'},
-            body: data
-          };
-          console.log("POST " + resource + " " + JSON.stringify(requestOpts))
-          response = await this.$Amplify.API.post(apiName, resource, requestOpts);
-          console.log(response)
-          console.log(JSON.stringify(response))
-          console.log("Started Glue ETL job")
+          let s3keysList = this.s3key.split(',').map((item) => item.trim())
+
+          for (let key of s3keysList) {
+            console.log("Starting Glue ETL job for s3://" + this.DATA_BUCKET_NAME + "/" + key)
+            resource = 'start_amc_transformation'
+            data = {'sourceBucket': this.DATA_BUCKET_NAME, 'sourceKey': key, 'outputBucket': this.ARTIFACT_BUCKET_NAME, 'piiFields': JSON.stringify(this.pii_fields),'deletedFields': JSON.stringify(this.deleted_columns), 'timestampColumn': this.timestamp_column_name, 'datasetId': this.dataset_definition.dataSetId}
+            let requestOpts = {
+              headers: {'Content-Type': 'application/json'},
+              body: data
+            };
+            console.log("POST " + resource + " " + JSON.stringify(requestOpts))
+            response = await this.$Amplify.API.post(apiName, resource, requestOpts);
+            console.log(response)
+            console.log(JSON.stringify(response))
+            console.log("Started Glue ETL job")
+          }
           
           // Navigate to next step
           this.$router.push('Step5')

--- a/source/website/src/views/Step4.vue
+++ b/source/website/src/views/Step4.vue
@@ -38,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
             </b-row>
             <b-row>
               <b-col cols="7">
-                <h5>Input files from {{"s3://" + DATA_BUCKET_NAME}}:</h5>
+                <h5>Input files from {{ "s3://" + DATA_BUCKET_NAME }}:</h5>
                 {{ s3key }}
                 <br>
                 <br>


### PR DESCRIPTION
*Issue #, if available:*
Closes #4 #51  

*Description of changes:*
- Allow users to select multiple files in Step 1 with the same schema and upload them into a new data set
- The maximum amount of Glue jobs that can concurrently is 200.

*Implementation:*
- Updates to the `get_data_columns` API to validate if files being uploaded are less than 200 and that they are the same schema. Otherwise, API will return a 400 error.
- Schema error thrown from added validation:
![Screen Shot 2023-01-11 at 3 20 47 PM](https://user-images.githubusercontent.com/122312553/211939065-e947dce3-1360-43ba-883d-8bb3b1594947.png)

- Updates to the Step 1 UI to allow multi-select. File names are appended to a comma delimited string. This was chosen over an array since it was more compatible with Vue Bootstrap's input field.
- Step 1 UI multi-select:
![Screen Shot 2023-01-11 at 3 19 44 PM](https://user-images.githubusercontent.com/122312553/211938942-e32bd1cc-d260-4a95-aa7c-5abd1785ec2c.png)

- Updates to the Step 4 UI to trigger a Glue ETL job for each file and minor text revisions.
- Step 4 UI before uploading:
![Screen Shot 2023-01-11 at 3 21 50 PM](https://user-images.githubusercontent.com/122312553/211939182-9a1dce0c-600c-4694-b6b3-e263daff9a50.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
