### PR TITLE
Revert " Resolve "Chalice fails with Python 3.10""

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -85,11 +85,6 @@ jobs:
       - name: Run build script
         id: builder
         run: |
-          sudo apt update
-          sudo apt install software-properties-common
-          sudo add-apt-repository ppa:deadsnakes/ppa
-          sudo apt-get install python3.9 nodejs npm zip
-          sudo apt-get install python3.9-venv python3.8-venv python3-pip
           cd deployment
           aws s3 mb s3://$DIST_OUTPUT_BUCKET-$REGION 
           aws s3 mb s3://$TEMPLATE_OUTPUT_BUCKET 

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -164,24 +164,24 @@ regional_dist_dir="$build_dir/regional-s3-assets"
 echo "------------------------------------------------------------------------------"
 echo "Creating a temporary Python virtualenv for this script"
 echo "------------------------------------------------------------------------------"
-python3.9 -c "import os; print (os.getenv('VIRTUAL_ENV'))" | grep -q None
+python3 -c "import os; print (os.getenv('VIRTUAL_ENV'))" | grep -q None
 if [ $? -ne 0 ]; then
     echo "ERROR: Do not run this script inside Virtualenv. Type \`deactivate\` and run again.";
     exit 1;
 fi
-command -v python3.9
+command -v python3
 if [ $? -ne 0 ]; then
-    echo "ERROR: install python3.9 before running this script"
+    echo "ERROR: install Python3 before running this script"
     exit 1
 fi
 echo "Using virtual python environment:"
 VENV=$(mktemp -d) && echo "$VENV"
-command -v python3.9 > /dev/null
+command -v python3 > /dev/null
 if [ $? -ne 0 ]; then
-    echo "ERROR: install python3.9 before running this script"
+    echo "ERROR: install Python3 before running this script"
     exit 1
 fi
-python3.9 -m venv "$VENV"
+python3 -m venv "$VENV"
 source "$VENV"/bin/activate
 pip3 install wheel
 pip3 install --quiet boto3 chalice requests aws_xray_sdk


### PR DESCRIPTION
Reverts aws-solutions/amazon-marketing-cloud-uploader-from-aws#33

I'm reverting this merge because:

* it broke the selenium-workflow
* we should not use questionably trusted repositories such as ppa:deadsnakes/ppa 

Try this instead:
```sudo add-apt-repository universe
sudo apt update
sudo apt install python3.9```