### PR TITLE
remove the stack if it exists before trying to create it again

### DIFF
--- a/.github/workflows/selenium-workflow.yml
+++ b/.github/workflows/selenium-workflow.yml
@@ -85,6 +85,9 @@ jobs:
           echo "DATA_UPLOAD_ACCOUNT_ID=${{secrets.DATA_UPLOAD_ACCOUNT_ID}}" >> $GITHUB_ENV
       - name: Deploy
         run: |
+          echo "Removing stack $STACK_NAME if it exists."
+          aws cloudformation delete-stack --stack-name $STACK_NAME
+          aws cloudformation wait stack-delete-complete --stack-name $STACK_NAME
           echo "Creating the stack"
           aws cloudformation create-stack --stack-name $STACK_NAME --template-url $TEMPLATE --parameters ParameterKey=AdminEmail,ParameterValue=$EMAIL ParameterKey=DataBucketName,ParameterValue=$DATA_BUCKET_NAME ParameterKey=AmcEndpointUrl,ParameterValue=$AMC_API_ENDPOINT ParameterKey=DataUploadAccountId,ParameterValue=$DATA_UPLOAD_ACCOUNT_ID --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --disable-rollback
           aws cloudformation wait stack-create-complete --stack-name $STACK_NAME


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The selenium stack will fail if it didn't remove the stack during the previous run. That delete-stack step is intentionally skipped so that we can troubleshoot selenium errors, but we don't want that to break subsequent workflow executions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
