### PR TITLE
remove unused code

### DIFF
--- a/source/glue/amc_transformations.py
+++ b/source/glue/amc_transformations.py
@@ -251,8 +251,6 @@ if 'period' in args:
         print("ERROR: Invalid user-defined value for dataset period:")
         print(user_defined_partition_size)
         exit(1)
-else:
-    user_defined_partition_size = 'autodetect'
 
 # Read optional parameters
 try:


### PR DESCRIPTION
Remove 'else' block that is not used in Glue script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
