### PR TITLE
Add feature to export and import schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automate front-end tests [#32]
 - Automate build and deploy tests [#34]  
 - Invalid email addresses should normalize to empty string and added unit tests to github pr-workflow. [#63]
+- Add Import/Export to Step 3 (Define columns), so user can import or export column schema for AMC ingestion. [#48]
 
 ### Changed
 

--- a/source/tests/e2e/conftest.py
+++ b/source/tests/e2e/conftest.py
@@ -27,7 +27,8 @@ def test_environment():
             'SECRET_KEY': os.environ['AWS_SECRET_ACCESS_KEY'],
             'EMAIL': os.environ['EMAIL'],
             'PASSWORD': os.environ['PASSWORD'],
-            'DATA_BUCKET_NAME': os.environ['DATA_BUCKET_NAME']
+            'DATA_BUCKET_NAME': os.environ['DATA_BUCKET_NAME'],
+            'LOCALHOST_URL': os.environ.get('LOCALHOST_URL')
         }
 
     except KeyError as e:

--- a/source/tests/e2e/run_e2e.sh
+++ b/source/tests/e2e/run_e2e.sh
@@ -195,6 +195,7 @@ export STACK_NAME=$stack_name
 export EMAIL=$EMAIL
 export PASSWORD=$PASSWORD 
 export DATA_BUCKET_NAME=$DATA_BUCKET_NAME
+export LOCALHOST_URL=$LOCALHOST_URL
 pytest -s -W ignore::DeprecationWarning -p no:cacheproviders
 
 if [ $? -ne 0 ]; then

--- a/source/tests/e2e/test_app.py
+++ b/source/tests/e2e/test_app.py
@@ -28,7 +28,7 @@ def browser():
 
 def test_everything(browser, test_environment, stack_resources):
     browser.implicitly_wait(5)
-    browser.get(stack_resources['UserInterface'])
+    browser.get(test_environment.get("LOCALHOST_URL") or stack_resources['UserInterface'])
     wait = WebDriverWait(browser, 30)
     # Login
     username_field = browser.find_element("xpath", "/html/body/div/div/div/div/div[2]/div[1]/div/input")
@@ -97,6 +97,18 @@ def test_everything(browser, test_environment, stack_resources):
     # and the first option should be selected by default
     assert len(browser.find_elements(By.ID, "time_period_options"))
     assert browser.find_element(By.XPATH, '//*[@id="time_period_options_BV_option_0"]').is_selected()
+
+    # open Step 3
+    browser.find_element(By.ID, "step3").click()
+
+    assert browser.find_element(By.XPATH, "//button[contains(text(), 'Export')]")
+    assert browser.find_element(By.XPATH, "//button[@title='Export column schema']")
+    assert browser.find_element(By.XPATH, "//button[contains(text(), 'Import')]")
+    assert browser.find_element(By.XPATH, "//button[@title='Import column schema']")
+    assert browser.find_element(By.XPATH, "//button[contains(text(), 'Reset')]")
+
+    assert browser.find_element(By.XPATH, "//button[contains(text(), 'Next')]")
+    assert browser.find_element(By.XPATH, "//button[contains(text(), 'Previous')]")
 
     # Sign out
     browser.find_element("xpath", "/html/body/div/div/div/div[1]/nav/div/ul/li/a").click()

--- a/source/website/src/views/Step3.vue
+++ b/source/website/src/views/Step3.vue
@@ -320,26 +320,34 @@ SPDX-License-Identifier: Apache-2.0
           reader.onload = e => {
             console.log(e.target.result);
             let importJson = JSON.parse(e.target.result);
-            if (!importJson.length){
+            if(importJson.constructor != Object){
+              alert("Invalid Schema: Expecting a dictionary.")
+              return
+            }
+            if (!Object.keys(importJson).length){
               alert("Invalid Schema: Json file is empty.")
               return
             }
-            if (!("column" in importJson)){
+            if (!("columns" in importJson)){
               alert("Invalid Schema: Column is required in imported schema.")
               return
             }
-            if (!importJson.column.length){
+            if (!importJson.columns.length){
               alert("Invalid Schema: Column is empty.")
               return
             }
 
-            valid_keys = ["name", "description", "data_type", "column_type", "pii_type", "nullable"]
-            for (var key in importJson.column){
-              if (!valid_keys.includes(key)){
-                alert("Invalid Schema: Only these valid keys {1} are required.".format(valid_keys))
-                return
-              } 
+            let valid_keys = ["name", "description", "data_type", "column_type", "pii_type", "nullable"]
+            for (var column_index in importJson.columns){
+                let column = importJson.columns[column_index]
+                for (var key in column){
+                if (!valid_keys.includes(key)){
+                  alert("Invalid Schema: Only these valid column keys ".concat(valid_keys).concat(" are required."))
+                  return
+                } 
+              }
             }
+           
 
             this.isBusy = true;
             console.log(importJson)

--- a/source/website/src/views/Step3.vue
+++ b/source/website/src/views/Step3.vue
@@ -155,10 +155,10 @@ SPDX-License-Identifier: Apache-2.0
             <b-row>
               <b-col></b-col>
               <b-col sm="4" align="right" class="row align-items-end">
-                <b-button v-b-tooltip.hover type="submit" title="Export column schema" variant="outline-secondary" @click="onExport">
+                <b-button v-b-tooltip.hover type="submit" title="Export column schema" variant="outline-primary" @click="onExport">
                   Export
                 </b-button> &nbsp;
-                <b-button v-b-tooltip.hover type="submit" title="Import column schema" variant="outline-secondary" @click="onBrowseImports">
+                <b-button v-b-tooltip.hover type="submit" title="Import column schema" variant="outline-primary" @click="onBrowseImports">
                   Import
                 </b-button>&nbsp;
                 <b-button type="submit" variant="outline-secondary" @click="onReset">
@@ -319,8 +319,17 @@ SPDX-License-Identifier: Apache-2.0
           let reader = new FileReader();
           reader.onload = e => {
             console.log("Imported schema: ".concat(e.target.result))
-            let importJson = JSON.parse(e.target.result);
-            this.$refs['file'].reset()
+            let importJson = null;
+            try {
+              importJson = JSON.parse(e.target.result);
+            } catch(e) { 
+              console.log(e)
+              alert("Invalid Schema: Json file is invalid")
+              return 
+            } finally {
+              this.$refs['file'].reset()
+            }
+
             if(importJson.constructor != Object){
               alert("Invalid Schema: Expecting a dictionary.")
               return

--- a/source/website/src/views/Step3.vue
+++ b/source/website/src/views/Step3.vue
@@ -306,7 +306,7 @@ SPDX-License-Identifier: Apache-2.0
         a.href = URL.createObjectURL(file);
         a.download = "amcufa_exported_schema_" + Date.now() + ".json";
         a.click();
-        console.log("Schema Exported")
+        console.log("Schema Exported: ".concat(JSON.stringify({"columns": this.items })))
       },
       onBrowseImports(){
         if (confirm("WARNING: This will reset the columns!")) {
@@ -318,7 +318,7 @@ SPDX-License-Identifier: Apache-2.0
           if (!files.length) return;
           let reader = new FileReader();
           reader.onload = e => {
-            console.log(e.target.result);
+            console.log("Imported schema: ".concat(e.target.result))
             let importJson = JSON.parse(e.target.result);
             this.$refs['file'].reset()
             if(importJson.constructor != Object){
@@ -330,7 +330,11 @@ SPDX-License-Identifier: Apache-2.0
               return
             }
             if (!("columns" in importJson)){
-              alert("Invalid Schema: Column is required in imported schema.")
+              alert("Invalid Schema: columns key is required in imported schema.")
+              return
+            }
+            if (importJson.columns.constructor.name != "Array"){
+              alert("Invalid Schema: Expecting an array type for columns key.")
               return
             }
             if (!importJson.columns.length){
@@ -351,7 +355,6 @@ SPDX-License-Identifier: Apache-2.0
            
 
             this.isBusy = true;
-            console.log(importJson)
             this.column_type_options.forEach(x => x.disabled = false)
             this.pii_type_options.forEach(x => x.disabled = false)
             this.items = importJson.columns.map(x => {return {
@@ -365,6 +368,7 @@ SPDX-License-Identifier: Apache-2.0
             })
             this.$store.commit('saveStep3FormInput', this.items)
             this.isBusy = false;
+            console.log("Schema Imported.")
           };
           reader.readAsText(files[0]);
       },

--- a/source/website/src/views/Step3.vue
+++ b/source/website/src/views/Step3.vue
@@ -338,7 +338,7 @@ SPDX-License-Identifier: Apache-2.0
               return
             }
             if (!importJson.columns.length){
-              alert("Invalid Schema: Column is empty.")
+              alert("Invalid Schema: columns key is empty.")
               return
             }
 

--- a/source/website/src/views/Step3.vue
+++ b/source/website/src/views/Step3.vue
@@ -320,6 +320,7 @@ SPDX-License-Identifier: Apache-2.0
           reader.onload = e => {
             console.log(e.target.result);
             let importJson = JSON.parse(e.target.result);
+            this.$refs['file'].reset()
             if(importJson.constructor != Object){
               alert("Invalid Schema: Expecting a dictionary.")
               return


### PR DESCRIPTION
*Issue #, if available:*
#48 

*Description of changes:*
* Add Import/Export to Step 3 (Define columns), so user can import or export column schema for AMC ingestion.


## Import
![import_gif](https://user-images.githubusercontent.com/7339334/215007459-c5711010-678a-4c65-af81-f6fb8cf33514.gif)

## Export
![export_gif](https://user-images.githubusercontent.com/7339334/215007479-921712a6-7c1a-42ad-a381-384fe595e9e3.gif)

## Invalid Schema
![invalid_schema](https://user-images.githubusercontent.com/7339334/215007482-e6e1c690-1443-4b9e-8281-6232e90244eb.gif)

## Screenshot
![image](https://user-images.githubusercontent.com/7339334/215007577-c133031e-7ed5-4b6a-9745-f4d6f4b429cd.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
