### PR TITLE
add functionality for additional locales

### DIFF
--- a/source/glue/amc_transformations.py
+++ b/source/glue/amc_transformations.py
@@ -96,6 +96,13 @@ def check_params(required: list, optional: list) -> dict:
     if args["country_code"] not in (
         "US",
         "UK",
+        "JP",
+        "IN",
+        "IT",
+        "ES",
+        "CA",
+        "DE",
+        "FR",
     ):
         print("ERROR: Invalid user-defined value for country:")
         print(args["country_code"])

--- a/source/website/src/views/Step3.vue
+++ b/source/website/src/views/Step3.vue
@@ -197,6 +197,27 @@ SPDX-License-Identifier: Apache-2.0
                       <b-form-select-option value="UK">
                         UK
                       </b-form-select-option>
+                      <b-form-select-option value="JP">
+                        JP
+                      </b-form-select-option>
+                      <b-form-select-option value="IN">
+                        IN
+                      </b-form-select-option>
+                      <b-form-select-option value="IT">
+                        IT
+                      </b-form-select-option>
+                      <b-form-select-option value="ES">
+                        ES
+                      </b-form-select-option>
+                      <b-form-select-option value="CA">
+                        CA
+                      </b-form-select-option>
+                      <b-form-select-option value="DE">
+                        DE
+                      </b-form-select-option>
+                      <b-form-select-option value="FR">
+                        FR
+                      </b-form-select-option>
                     </b-form-select>
                   </b-form-group>
                 </b-col>


### PR DESCRIPTION
Added locales:
JP, IN, IT, ES, CA, DE, & FR

*Issue #, if available:*
#121 #122 #123 #124 #125 #126 #143 

*Description of changes:*
- Add country codes to frontend
- Add country codes to Glue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
