### PR TITLE
Pull amazonlinux from Amazon ECR

### DIFF
--- a/deployment/lambda_layer_factory/Dockerfile
+++ b/deployment/lambda_layer_factory/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM public.ecr.aws/amazonlinux/amazonlinux
 
 WORKDIR /
 RUN yum update -y


### PR DESCRIPTION
*Issue #, if available:*

Clsoes #163 

*Description of changes:*

Pull the Amazon Linux container image from Amazon ECR Public instead of Docker Hub.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
