### PR TITLE
remove redundant log group

### DIFF
--- a/deployment/amazon-marketing-cloud-uploader-from-aws.yaml
+++ b/deployment/amazon-marketing-cloud-uploader-from-aws.yaml
@@ -820,17 +820,6 @@ Resources:
       Runtime:  python3.8
       Timeout: 180
 
-  AnonymousDataCustomResourceLogGroup:
-    Type: AWS::Logs::LogGroup
-    Metadata:
-      cfn_nag:
-        rules_to_suppress:
-          - id: W84
-            reason: "The data generated via this role does not need to be encrypted."
-    Properties:
-      LogGroupName: !Join ['/', ['/aws/lambda', !Ref AnonymousDataCustomResource]]
-      RetentionInDays: 30
-
   # SendAnonymousData
   AnonymousDataUuid:
     Type: "Custom::UUID"


### PR DESCRIPTION
*Issue #, if available:*

Closes #167 

*Description of changes:*

Remove the AnonymousDataCustomResourceLogGroup resource since it is redundant to the default log group.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
