### PR TITLE
Prevent users from adding too many AMC instances

### DIFF
--- a/source/website/src/views/Settings.vue
+++ b/source/website/src/views/Settings.vue
@@ -43,6 +43,12 @@ SPDX-License-Identifier: Apache-2.0
             >
               Import failed. Check data format.
             </b-alert>
+            <b-alert
+              :show="amcInstances.length > 259"
+              variant="danger"
+            >
+              AMC instance list is too long. Length {{ amcInstances.length }} exceeds maximum allowable limit of 259. 
+            </b-alert>
             <b-row>
               <b-col cols="10">
                 <h3>AMC Instances</h3>
@@ -179,7 +185,7 @@ SPDX-License-Identifier: Apache-2.0
     },
     computed: {
       isValidForm() {
-        return this.amcInstances.length > 0 && this.amcInstances.every(x => this.isValidEndpoint(x.endpoint) !== false && this.isValidAccountId(x.data_upload_account_id) !== false)
+        return this.amcInstances.length > 0 && this.amcInstances.length < 260 && this.amcInstances.every(x => this.isValidEndpoint(x.endpoint) !== false && this.isValidAccountId(x.data_upload_account_id) !== false)
       }
     },
     deactivated: function () {


### PR DESCRIPTION
*Issue #, if available:*

Closes #171 

*Description of changes:*

Updates Settings.vue to disable the Save button and show the following alert when the user tries to add more than 259 AMC instances:

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/54998167/225410999-fca14c65-35a0-4e64-885f-a9095398c544.png">

This also works with the Import button.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
