### PR TITLE
Simplify endpoint encoding

### DIFF
--- a/source/amc_uploader/amc_uploader.py
+++ b/source/amc_uploader/amc_uploader.py
@@ -12,12 +12,11 @@
 #
 # REQUIREMENTS:
 #   Input files should be in a location like this:
-#     s3://[bucket_name]/[dataset_id]/[timeseries_partition_size]/[base64_encoded_destination_endpoint]/[filename]
+#     s3://[bucket_name]/[dataset_id]/[timeseries_partition_size]/[destination_endpoint]/[filename]
 #   Such as,
 #     s3://my_etl_artifacts/myDataset123/P1D/aHR0cHM6Ly9hYmNkZTEyMzQ1LmV4ZWN1dGUtYXBpLnVzLWVhc3QtMS5hbWF6b25hd3MuY29tL3Byb2Q=/amc-data-mid.json-2014_03_12-19:06:00.gz
 ###############################################################################
 
-import base64
 import json
 import logging
 import os
@@ -76,7 +75,7 @@ def _is_timeseries(key):
         "P7D",
     )
     # Time series datasets will have the following s3key pattern:
-    #   amc/[dataset_id]/[timeseries_partition_size]/[base64_encoded_destination_endpoint][filename]
+    #   amc/[dataset_id]/[timeseries_partition_size]/[destination_endpoint][filename]
     return (len(key.split("/")) == 5) and (
         key.split("/")[2].endswith(supported_time_partitions)
     )
@@ -86,13 +85,10 @@ def _start_fact_upload(bucket, key):
     try:
         logger.info("Uploading FACT dataset")
         # Key parsing assume s3Key is in the following format:
-        #   amc/[datasetId]/[amc time resolution code]/[base64_encoded_destination_endpoint]/[datafile].gz
+        #   amc/[datasetId]/[amc time resolution code]/[destination_endpoint]/[datafile].gz
         dataset_id = key.split("/")[1]
         time_partition = key.split("/")[2]
-        base64_encoded_destination_endpoint = key.split("/")[3]
-        destination_endpoint = base64.b64decode(
-            base64_encoded_destination_endpoint
-        ).decode("ascii")
+        destination_endpoint = 'https://' + key.split("/")[3] + '/prod'
         filename = urllib.parse.unquote(key.split("/")[-1])
         # Parse the filename to get the time window for that data.
         # Filenames should look like this, "etl_output_data.json-2022_01_06-09:01:00.gz"
@@ -171,12 +167,9 @@ def _start_dimension_upload(bucket, key):
     try:
         logger.info("Uploading DIMENSION dataset")
         # Key parsing assume s3Key is in the following format:
-        #   amc/[datasetId]/dimension/base64_encoded_destination_endpoint/[datafile].gz
+        #   amc/[datasetId]/dimension/destination_endpoint/[datafile].gz
         dataset_id = key.split("/")[1]
-        base64_encoded_destination_endpoint = key.split("/")[3]
-        destination_endpoint = base64.b64decode(
-            base64_encoded_destination_endpoint
-        ).decode("ascii")
+        destination_endpoint = 'https://' + key.split("/")[3] + '/prod'
         filename = urllib.parse.unquote(key.split("/")[-1])
         logger.info("key: " + key)
         logger.info("dataset_id " + dataset_id)


### PR DESCRIPTION
*Issue #, if available:*

Closes #179 

*Description of changes:*

Encode destination endpoint with base_url instead of base64. 

After this PR has been merged, the ETL artifacts will save into a directory that looks like this:


`s3://stack-etl-artifact-123456/amc/dataset_name/P1D/sample_endpoint.execute-api.us-east-1.amazonaws.com/`

instead of this:

`s3://stack-etl-artifact-123456/amc/dataset_name/P1D/aHR0cHM6Ly9zYW1wbGVfZW5kcG9pbnQuZXhlY3V0ZS1hcGkudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vcHJvZC8=/`

T