### PR TITLE
replace Date column type with Timestamp type

### DIFF
--- a/source/website/src/views/Step4.vue
+++ b/source/website/src/views/Step4.vue
@@ -593,7 +593,7 @@ SPDX-License-Identifier: Apache-2.0
             const column_definition = {
               "name": x.name,
               "description": x.description,
-              "dataType": x.data_type,
+              "dataType": "TIMESTAMP",
               "isMainEventTime": true
             }
             this.columns.push(column_definition)


### PR DESCRIPTION
*Issue #, if available:*

Closes #199 

*Description of changes:*

Always use Timestamp column type for the main event time column. This will fix an upload error that occurs if the Date column type is used.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
