### PR TITLE
Fix error removing records from the upload_failures_table.

### DIFF
--- a/source/amc_uploader/amc_uploader.py
+++ b/source/amc_uploader/amc_uploader.py
@@ -165,7 +165,7 @@ def _start_fact_upload(bucket, key):
         upload_failures_table = dynamo_resource.Table(UPLOAD_FAILURES_TABLE_NAME)
         item_key = {"dataset_id": dataset_id, "destination_endpoint": destination_endpoint}
         try:
-            upload_failures_table.delete_item(Key=item_key, ConditionExpression="attribute_exists(item_key)")
+            upload_failures_table.delete_item(Key=item_key)
         except dynamo_resource.meta.client.exceptions.ConditionalCheckFailedException:
             pass
         if response.status_code != 200:

--- a/source/api/app.py
+++ b/source/api/app.py
@@ -395,7 +395,7 @@ def delete_dataset():
                         json.dumps(item_key))
             upload_failures_table = dynamo_resource.Table(UPLOAD_FAILURES_TABLE_NAME)
             try:
-                upload_failures_table.delete_item(Key=item_key, ConditionExpression="attribute_exists(item_key)")
+                upload_failures_table.delete_item(Key=item_key)
             except dynamo_resource.meta.client.exceptions.ConditionalCheckFailedException:
                 pass
         return Response(


### PR DESCRIPTION
*Issue #, if available:*

none

*Description of changes:*

This fixes an error in #221 which prevented messages from being removed from the upload_failures_table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
