### PR TITLE
Enhance s3 logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - tbd
+
+### Changed
+
+* Enhance the protection of S3 access logs. (#232)
+
 ## [2.0.0] - 2023-04-17
 
 ### Added

--- a/deployment/amazon-marketing-cloud-uploader-from-aws.yaml
+++ b/deployment/amazon-marketing-cloud-uploader-from-aws.yaml
@@ -115,12 +115,40 @@ Resources:
             Condition:
               Bool:
                 aws:SecureTransport: false
+          - Sid: "S3ServerAccessLogsPolicy"
+            Effect: Allow
+            Principal:
+              Service:
+                - logging.s3.amazonaws.com
+            Action: 's3:PutObject'
+            Resource:
+              - !Join [
+                "",
+                [
+                  "arn:",
+                  Ref: "AWS::Partition",
+                  ":s3:::",
+                  Ref: ArtifactLogsBucket,
+                  "/access_logs/*"
+                ]
+              ]
+            Condition:
+              ArnLike:
+                aws:SourceArn: 
+                  - !Join [
+                    "",
+                    [
+                      "arn:",
+                      Ref: "AWS::Partition",
+                      ":s3:::",
+                      Ref: ArtifactLogsBucket
+                    ]
+                  ]
 
   ArtifactLogsBucket:
     DeletionPolicy: "Delete"
     Type: AWS::S3::Bucket
     Properties:
-      AccessControl: LogDeliveryWrite
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault: !If
@@ -131,9 +159,6 @@ Resources:
               -
                 SSEAlgorithm: "aws:kms"
                 KMSMasterKeyID: !Ref SystemKeyAlias
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: ObjectWriter
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -181,9 +206,6 @@ Resources:
       LoggingConfiguration:
         DestinationBucketName: !Ref ArtifactLogsBucket
         LogFilePrefix: "access_logs/"
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: ObjectWriter
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/deployment/web.yaml
+++ b/deployment/web.yaml
@@ -165,12 +165,18 @@ Resources:
         Ref: "WebsiteBucket"
       PolicyDocument:
         Statement:
-          - Effect: "Allow"
+          - Effect: Allow
             Action:
               - "s3:GetObject"
             Resource:
               - !Sub "arn:aws:s3:::${WebsiteBucket}"
               - !Sub "arn:aws:s3:::${WebsiteBucket}/*"
+            Principal:
+              CanonicalUser: !GetAtt OriginAccessIdentity.S3CanonicalUserId
+          - Effect: Deny
+            Action: "*"
+            Resource:
+              - !Sub "arn:aws:s3:::${WebsiteBucket}/*logs*/*"
             Principal:
               CanonicalUser: !GetAtt OriginAccessIdentity.S3CanonicalUserId
           - Effect: Deny


### PR DESCRIPTION
*Issue #, if available:*

#232

*Description of changes:*

   * Deny CloudFront access to *logs* in the WebsiteBucket
   * Replace the AccessControl: LogDeliveryWrite property on the ArtifactLogsBucket with a bucket policy that grants the logging service principal logging.s3.amazonaws.com privileges to write access logs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
